### PR TITLE
Adjust #rank_of_card_at

### DIFF
--- a/lib/deck.rb
+++ b/lib/deck.rb
@@ -5,9 +5,14 @@ class Deck
     @cards = cards
   end
 
+  # def rank_of_card_at(index)
+  #   card = @cards[index]
+  #   card.rank if card
+  # end
+
   def rank_of_card_at(index)
-    card = @cards[index]
-    card.rank if card
+    return 0 if cards[index] == nil
+    cards[index].rank
   end
 
   def high_ranking_cards

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -62,7 +62,7 @@ class Game
   end
 
   def print_draw_message
-    puts "Turn #{@turn_counter}: DRAW"
+    puts "Turn #{@turn_counter}: ---- DRAW ----"
   end
 
   def draw?

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -10,9 +10,9 @@ class Turn
   end
 
   def type
-    if player1.deck.cards[0].rank == player2.deck.cards[0].rank && player1.deck.cards[2].rank == player2.deck.cards[2].rank
+    if player1.deck.rank_of_card_at(0) == player2.deck.rank_of_card_at(0) && player1.deck.rank_of_card_at(2) == player2.deck.rank_of_card_at(2)
       :mutually_assured_destruction
-    elsif player1.deck.cards[0].rank == player2.deck.cards[0].rank
+    elsif player1.deck.rank_of_card_at(0) == player2.deck.rank_of_card_at(0)
       :war
     else
       :basic
@@ -46,12 +46,12 @@ class Turn
   end
 
   def basic_play
-    return player1 if player1.deck.cards[0].rank > player2.deck.cards[0].rank
+    return player1 if player1.deck.rank_of_card_at(0) > player2.deck.rank_of_card_at(0)
     player2
   end
 
   def war_play
-    return player1 if player1.deck.cards[2].rank > player2.deck.cards[2].rank
+    return player1 if player1.deck.rank_of_card_at(2) > player2.deck.rank_of_card_at(2)
     player2
   end
 
@@ -63,6 +63,7 @@ class Turn
   def basic_pile
     spoils_of_war << player1.deck.cards.shift
     spoils_of_war << player2.deck.cards.shift
+
   end
 
   def war_pile

--- a/spec/deck_builder_spec.rb
+++ b/spec/deck_builder_spec.rb
@@ -3,7 +3,7 @@ require "./lib/deck"
 require "./lib/deck_builder"
 
 RSpec.describe DeckBuilder do
-  let!(:git deck_builder) { DeckBuilder.new }
+  let!(:deck_builder) { DeckBuilder.new }
 
   it "exists" do
     expect(deck_builder).to be_a(DeckBuilder)

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -31,33 +31,50 @@ let!(:game) { Game.new(player1, player2) }
     expect(game.player2).to eq(player2)
   end
 
-  describe "#start" do
-    xit "displays the welcome message" do
-      expected_output = <<-EXPECTED
+#   describe "#start" do
+#     xit "displays the welcome message" do
+#       expected_output = <<-EXPECTED
+# Welcome to War! (or Peace) This game will be played with 52 cards.
+# The players today are #{player1.name} and #{player2.name}.
+# Type 'GO' to start the game!
+# ------------------------------------------------------------------
+#       EXPECTED
+
+#       # expected_output = "Welcome to War! (or Peace) This game will be played with 52 cards.\nThe players today are Joey and Josephinie.\nType 'GO' to start the game!\n------------------------------------------------------------------\n"
+
+#       actual_output = `ruby pieces_of_war_runner.rb`
+
+#       expect(actual_output).to eq(expected_output)
+#     end
+
+    it "displays the welcome message" do
+      expected = <<-EXPECTED
 Welcome to War! (or Peace) This game will be played with 52 cards.
 The players today are #{player1.name} and #{player2.name}.
 Type 'GO' to start the game!
 ------------------------------------------------------------------
-      EXPECTED
-
-      # expected_output = "Welcome to War! (or Peace) This game will be played with 52 cards.\nThe players today are Joey and Josephinie.\nType 'GO' to start the game!\n------------------------------------------------------------------\n"
-
-      actual_output = `ruby pieces_of_war_runner.rb`
-
-      expect(actual_output).to eq(expected_output)
-    end
-
-    it "displays the welcome message" do
+            EXPECTED
       # allow method mocks the start_game_on_user_input method
       # "allow" will allow the test to be isolated and focus on the behavior of the method
       allow(game).to receive(:start_game_on_user_input)
       # asserts that game.start returns a message that contains
       expect { game.start }.to output(/Welcome to War! \(or Peace\)/).to_stdout
+      expect { game.start }.to output(expected).to_stdout
     end
 
+    xit "starts the game with user input" do
+      allow(game).to receive(:start_game_on_user_input)
+      allow(game).to receive(:gets).and_return("GO")
+      # expect(game).to receive(:play_game).at_least(:once)
+      expect(game).to receive(:take_turn).at_least(:once)
+      expect(game).to receive(:print_winner_messages).at_least(:once)
+      expect(game).to receive(:draw?).at_least(:once)
 
-    it "#play_game" do
+      game.start
+    end
+
+    xit "#play_game" do
       game.play_game
     end
-  end
+  # end
 end


### PR DESCRIPTION
This commit will adjust #rank_of_card_at to accept nil values and return a 0 when the cards no longer exist in the hand. This commit will also adjust the .rank method that was being called in the Turn class and it will call the .rank_of_card_at method instead. 

This inevitably was my error. Because I was calling rank instead of my written rank_of_card_at method, it was returning a nil value and breaking the #type method in the Turn class when there was a winner to the game. 